### PR TITLE
update setListFavorites to setFavorites

### DIFF
--- a/client/src/components/layout/MainLayout.jsx
+++ b/client/src/components/layout/MainLayout.jsx
@@ -9,7 +9,7 @@ import { useEffect } from "react";
 import { toast } from "react-toastify";
 import userApi from "../../api/modules/user.api";
 import favoriteApi from "../../api/modules/favorite.api";
-import { setListFavorites, setUser } from "../../redux/features/userSlice";
+import { setFavorites, setUser } from "../../redux/features/userSlice";
 
 const MainLayout = () => {
   const dispatch = useDispatch();
@@ -31,12 +31,12 @@ const MainLayout = () => {
     const getFavorites = async () => {
       const { response, err } = await favoriteApi.getList();
 
-      if (response) dispatch(setListFavorites(response));
+      if (response) dispatch(setFavorites(response));
       if (err) toast.error(err.message);
     };
 
     if (user) getFavorites();
-    if (!user) dispatch(setListFavorites([]));
+    if (!user) dispatch(setFavorites([]));
   }, [user, dispatch]);
 
   return (

--- a/client/src/redux/features/userSlice.js
+++ b/client/src/redux/features/userSlice.js
@@ -16,7 +16,7 @@ export const userSlice = createSlice({
 
       state.user = action.payload;
     },
-    setListFavorites: (state, action) => {
+    setFavorites: (state, action) => {
       state.listFavorites = action.payload;
     },
     removeFavorite: (state, action) => {
@@ -31,7 +31,7 @@ export const userSlice = createSlice({
 
 export const {
   setUser,
-  setListFavorites,
+  setFavorites,
   addFavorite,
   removeFavorite
 } = userSlice.actions;


### PR DESCRIPTION
## Overview
The method name, `setListFavorites` explicitly specifies it will set a list of favorites but due to the resource being plural it is already implied and so redundantly named. This PR addresses this.

## Changes
- Update setListFavorites methods to setFavorites

## Out of Scope
n/a

## Risks
n/a - This PR replaces one method in a couple places via a global search and replace.

## Authors
@odelavia @b-richardson 
