### PR TITLE
update element variable name wherever we map over arrays

### DIFF
--- a/client/src/components/common/BackdropSlide.jsx
+++ b/client/src/components/common/BackdropSlide.jsx
@@ -3,22 +3,19 @@ import { SwiperSlide } from "swiper/react";
 import tmdbConfigs from "../../api/configs/tmdb.configs";
 import NavigationSwiper from "./NavigationSwiper";
 
-const BackdropSlide = ({ backdrops }) => {
-  console.log("entered the backdropslide: ", backdrops)
-  return (
-    <NavigationSwiper>
-      {[...backdrops].splice(0, 10).map((backdrop, index) => (
-        <SwiperSlide key={index}>
-          <Box sx={{
-            paddingTop: "60%",
-            backgroundPosition: "top",
-            backgroundSize: "cover",
-            backgroundImage: `url(${tmdbConfigs.backdropPath(backdrop.file_path)})`
-          }} />
-        </SwiperSlide>
-      ))}
-    </NavigationSwiper>
-  );
-};
+const BackdropSlide = ({ backdrops }) => (
+  <NavigationSwiper>
+    {[...backdrops].splice(0, 10).map((backdrop, index) => (
+      <SwiperSlide key={index}>
+        <Box sx={{
+          paddingTop: "60%",
+          backgroundPosition: "top",
+          backgroundSize: "cover",
+          backgroundImage: `url(${tmdbConfigs.backdropPath(backdrop.file_path)})`
+        }} />
+      </SwiperSlide>
+    ))}
+  </NavigationSwiper>
+);
 
 export default BackdropSlide;

--- a/client/src/components/common/BackdropSlide.jsx
+++ b/client/src/components/common/BackdropSlide.jsx
@@ -4,15 +4,16 @@ import tmdbConfigs from "../../api/configs/tmdb.configs";
 import NavigationSwiper from "./NavigationSwiper";
 
 const BackdropSlide = ({ backdrops }) => {
+  console.log("entered the backdropslide: ", backdrops)
   return (
     <NavigationSwiper>
-      {[...backdrops].splice(0, 10).map((item, index) => (
+      {[...backdrops].splice(0, 10).map((backdrop, index) => (
         <SwiperSlide key={index}>
           <Box sx={{
             paddingTop: "60%",
             backgroundPosition: "top",
             backgroundSize: "cover",
-            backgroundImage: `url(${tmdbConfigs.backdropPath(item.file_path)})`
+            backgroundImage: `url(${tmdbConfigs.backdropPath(backdrop.file_path)})`
           }} />
         </SwiperSlide>
       ))}

--- a/client/src/components/common/Footer.jsx
+++ b/client/src/components/common/Footer.jsx
@@ -17,16 +17,17 @@ const Footer = () => {
         >
           <Logo />
           <Box>
-            {menuConfigs.main.map((item, index) => (
+            {menuConfigs.main.map((menuOption, index) => {
+              return (
               <Button
                 key={index}
                 sx={{ color: "inherit" }}
                 component={Link}
-                to={item.path}
+                to={menuOption.path}
               >
-                {item.display}
+                {menuOption.display}
               </Button>
-            ))}
+            )})}
           </Box>
         </Stack>
       </Paper>

--- a/client/src/components/common/MediaReview.jsx
+++ b/client/src/components/common/MediaReview.jsx
@@ -138,9 +138,9 @@ const MediaReview = ({ reviews, media, mediaType }) => {
     <>
       <Container header={`Reviews (${reviewCount})`}>
         <Stack spacing={4} marginBottom={2}>
-          {filteredReviews.map((item) => (
-            <Box key={item.id}>
-              <ReviewItem review={item} onRemoved={onRemoved} />
+          {filteredReviews.map((review) => (
+            <Box key={review.id}>
+              <ReviewItem review={review} onRemoved={onRemoved} />
               <Divider sx={{
                 display: { xs: "block", md: "none" }
               }} />

--- a/client/src/components/common/PosterSlide.jsx
+++ b/client/src/components/common/PosterSlide.jsx
@@ -6,13 +6,13 @@ import AutoSwiper from "./AutoSwiper";
 const PosterSlide = ({ posters }) => {
   return (
     <AutoSwiper>
-      {[...posters].splice(0, 10).map((item, index) => (
+      {[...posters].splice(0, 10).map((poster, index) => (
         <SwiperSlide key={index}>
           <Box sx={{
             paddingTop: "160%",
             backgroundPosition: "center",
             backgroundSize: "cover",
-            backgroundImage: `url(${tmdbConfigs.posterPath(item.file_path)})`
+            backgroundImage: `url(${tmdbConfigs.posterPath(poster.file_path)})`
           }} />
         </SwiperSlide>
       ))}

--- a/client/src/components/common/ProviderMenu.jsx
+++ b/client/src/components/common/ProviderMenu.jsx
@@ -34,16 +34,16 @@ const ProviderMenu = () => {
             onClose={() => setAnchorEl(null)}
             PaperProps={{ sx: { padding: 0 } }}
           >
-            {menuConfigs.provider.map((item, index) => (
+            {menuConfigs.provider.map((menuOption, index) => (
               <ListItemButton
                 component={Link}
-                to={item.path}
+                to={menuOption.path}
                 key={index}
                 onClick={() => setAnchorEl(null)}
               >
-                <ListItemIcon>{item.icon}</ListItemIcon>
+                <ListItemIcon>{menuOption.icon}</ListItemIcon>
                 <ListItemText disableTypography primary={
-                  <Typography textTransform="uppercase">{item.display}</Typography>
+                  <Typography textTransform="uppercase">{menuOption.display}</Typography>
                 } />
               </ListItemButton>
             ))}

--- a/client/src/components/common/Sidebar.jsx
+++ b/client/src/components/common/Sidebar.jsx
@@ -33,42 +33,42 @@ const Sidebar = ({ open, toggleSidebar }) => {
       </Toolbar>
       <List sx={{ paddingX: "30px" }}>
         <Typography variant="h6" marginBottom="20px">MENU</Typography>
-        {menuConfigs.main.map((item, index) => (
+        {menuConfigs.main.map((menuOption, index) => (
           <ListItemButton
             key={index}
             sx={{
               borderRadius: "10px",
               marginY: 1,
-              backgroundColor: appState.includes(item.state) ? "primary.main" : "unset"
+              backgroundColor: appState.includes(menuOption.state) ? "primary.main" : "unset"
             }}
             component={Link}
-            to={item.path}
+            to={menuOption.path}
             onClick={() => toggleSidebar(false)}
           >
-            <ListItemIcon>{item.icon}</ListItemIcon>
+            <ListItemIcon>{menuOption.icon}</ListItemIcon>
             <ListItemText disableTypography primary={<Typography textTransform="uppercase">
-              {item.display}
+              {menuOption.display}
             </Typography>} />
           </ListItemButton>
         ))}
 
         {user && (<>
           <Typography variant="h6" marginBottom="20px">PERSONAL</Typography>
-          {menuConfigs.user.map((item, index) => (
+          {menuConfigs.user.map((menuOption, index) => (
             <ListItemButton
               key={index}
               sx={{
                 borderRadius: "10px",
                 marginY: 1,
-                backgroundColor: appState.includes(item.state) ? "primary.main" : "unset"
+                backgroundColor: appState.includes(menuOption.state) ? "primary.main" : "unset"
               }}
               component={Link}
-              to={item.path}
+              to={menuOption.path}
               onClick={() => toggleSidebar(false)}
             >
-              <ListItemIcon>{item.icon}</ListItemIcon>
+              <ListItemIcon>{menuOption.icon}</ListItemIcon>
               <ListItemText disableTypography primary={<Typography textTransform="uppercase">
-                {item.display}
+                {menuOption.display}
               </Typography>} />
             </ListItemButton>
           ))}

--- a/client/src/components/common/Topbar.jsx
+++ b/client/src/components/common/Topbar.jsx
@@ -71,18 +71,18 @@ const Topbar = () => {
               <Box sx={{ marginRight: "30px" }}>
                 <Logo />
               </Box>
-              {menuConfigs.main.map((item, index) => (
+              {menuConfigs.main.map((menuOption, index) => (
                 <Button
                   key={index}
                   sx={{
-                    color: appState.includes(item.state) ? "primary.contrastText" : "inherit",
+                    color: appState.includes(menuOption.state) ? "primary.contrastText" : "inherit",
                     mr: 2
                   }}
                   component={Link}
-                  to={item.path}
-                  variant={appState.includes(item.state) ? "contained" : "text"}
+                  to={menuOption.path}
+                  variant={appState.includes(menuOption.state) ? "contained" : "text"}
                 >
-                  {item.display}
+                  {menuOption.display}
                 </Button>
               ))}
               <IconButton

--- a/client/src/components/common/UserMenu.jsx
+++ b/client/src/components/common/UserMenu.jsx
@@ -32,16 +32,16 @@ const UserMenu = () => {
             onClose={() => setAnchorEl(null)}
             PaperProps={{ sx: { padding: 0 } }}
           >
-            {menuConfigs.user.map((item, index) => (
+            {menuConfigs.user.map((menuOption, index) => (
               <ListItemButton
                 component={Link}
-                to={item.path}
+                to={menuOption.path}
                 key={index}
                 onClick={() => setAnchorEl(null)}
               >
-                <ListItemIcon>{item.icon}</ListItemIcon>
+                <ListItemIcon>{menuOption.icon}</ListItemIcon>
                 <ListItemText disableTypography primary={
-                  <Typography textTransform="uppercase">{item.display}</Typography>
+                  <Typography textTransform="uppercase">{menuOption.display}</Typography>
                 } />
               </ListItemButton>
             ))}

--- a/client/src/pages/MediaSearch.jsx
+++ b/client/src/pages/MediaSearch.jsx
@@ -72,17 +72,21 @@ const MediaSearch = () => {
             justifyContent="center"
             sx={{ width: "100%" }}
           >
-            {mediaTypes.map((item, index) => (
+            {
+              // NOTE: We use contentType instead of mediaType for the current
+              // element being processed below because mediaType is already
+              // taken.
+              mediaTypes.map((contentType, index) => (
               <Button
                 size="large"
                 key={index}
-                variant={mediaType === item ? "contained" : "text"}
+                variant={mediaType === contentType ? "contained" : "text"}
                 sx={{
-                  color: mediaType === item ? "primary.contrastText" : "text.primary"
+                  color: mediaType === contentType ? "primary.contrastText" : "text.primary"
                 }}
-                onClick={() => onCategoryChange(item)}
+                onClick={() => onCategoryChange(contentType)}
               >
-                {item}
+                {contentType}
               </Button>
             ))}
           </Stack>

--- a/client/src/pages/ReviewList.jsx
+++ b/client/src/pages/ReviewList.jsx
@@ -137,9 +137,9 @@ const ReviewList = () => {
     <Box sx={{ ...uiConfigs.style.mainContent }}>
       <Container header={`Your reviews (${count})`}>
         <Stack spacing={2}>
-          {filteredReviews.map((item) => (
-            <Box key={item.id}>
-              <ReviewItem review={item} onRemoved={onRemoved} />
+          {filteredReviews.map((review) => (
+            <Box key={review.id}>
+              <ReviewItem review={review} onRemoved={onRemoved} />
               <Divider sx={{
                 display: { xs: "block", md: "none" }
               }} />


### PR DESCRIPTION
## Overview
There are multiple instances in the code where we do `array.map((item, index) => (...))`. This is not very descriptive, especially to someone else trying to navigate the code for the first time. This PR addresses that.

## Changes
- rename all instances of item in `array.map((item, index) => (...))` to be more descriptive

## Risks
- Small risk I accidentally break something wherever we are mapping over an array but I did a global search and replace so it's minimal.

## Authors
@odelavia 
